### PR TITLE
Update SHA for papertrail bundle

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download Papertrail PEM
   get_url: url="https://papertrailapp.com/tools/papertrail-bundle.pem"
            dest="/etc/papertrail-bundle.pem"
-           sha256sum="c03a504397dc45b4fc05f978dbf02129793cbd2a0b64856c2ba1bb49a3b9aacb"
+           sha256sum="7019189e20ed695e9092e67d91a3b37249474f4c4c6355193ce6d2cb648f147c"
            mode=0644
 
 - name: Install TLS support for Rsyslog


### PR DESCRIPTION
They updated their bundle so the old SHA was invalid.