### PR TITLE
Extract remote_syslog if a download occurs

### DIFF
--- a/tasks/extract-remote-syslog.yml
+++ b/tasks/extract-remote-syslog.yml
@@ -1,0 +1,7 @@
+---
+- name: Extract remote_syslog
+  unarchive: src="/usr/local/src/remote_syslog_{{ papertrail_version }}_linux_amd64.tar.gz"
+             dest=/opt
+             copy=no
+             owner=root
+             group=root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download Papertrail PEM
   get_url: url="https://papertrailapp.com/tools/papertrail-bundle.pem"
            dest="/etc/papertrail-bundle.pem"
-           sha256sum="7019189e20ed695e9092e67d91a3b37249474f4c4c6355193ce6d2cb648f147c"
+           checksum="sha256:7019189e20ed695e9092e67d91a3b37249474f4c4c6355193ce6d2cb648f147c"
            mode=0644
 
 - name: Install TLS support for Rsyslog

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,14 +18,10 @@
 - name: Download remote_syslog
   get_url: url="https://github.com/papertrail/remote_syslog2/releases/download/v{{ papertrail_version }}/remote_syslog_linux_amd64.tar.gz"
            dest="/usr/local/src/remote_syslog_{{ papertrail_version }}_linux_amd64.tar.gz"
+  register: remote_syslog_download
 
-- name: Extract remote_syslog
-  unarchive: src="/usr/local/src/remote_syslog_{{ papertrail_version }}_linux_amd64.tar.gz"
-             dest=/opt
-             copy=no
-             owner=root
-             group=root
-             creates=/opt/remote_syslog/remote_syslog
+- include: extract-remote-syslog.yml
+  when: remote_syslog_download.changed
 
 - name: Configure Rsyslog to use Papertrail
   template: src="90-papertrail.conf.j2"


### PR DESCRIPTION
# Overview
Currently, we use the unarchive module's `creates` argument to ensure that remote_syslog extraction is idempotent. However, this also causes extractions to be skipped on hosts that already have remote_syslog installed at `/opt/remote_syslog/remote_syslog`. This PR modifies the extraction task to run anytime remote_syslog is downloaded, so that downloading a new version of remote_syslog forces an install.

Also, replace references to get_url's deprecated `sha256sum` argument with `checksum`. 

# Testing
- Run `vagrant up --provision` in the examples directory. Then, change `papertrail_version`, and run `vagrant provision` again. Make sure that the `Extract Remote Syslog` step runs both times.

Fixes #8
