### PR TITLE
Make CA bundle checksum configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An Ansible role for installing [Papertrail](https://papertrailapp.com).
 ## Role Variables
 
 - `papertrail_version` - Release of [remote_syslog2](https://github.com/papertrail/remote_syslog2) to use
+- `papertrail_ca_bundle_checksum` - Checksum for Papertrail CA bundle (default: `sha256:7019189e20ed695e9092e67d91a3b37249474f4c4c6355193ce6d2cb648f147c`)
 - `papertrail_conf` - Application logs configuration file (default: `/etc/log_files.yml`)
 - `papertrail_host` - Host for Papertrail's logging endpoint (default: `logs2.papertrail.com`)
 - `papertrail_port` - Port for Papertrail's logging endpoint (default: `45551`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ papertrail_conf: "/etc/log_files.yml"
 papertrail_host: "logs2.papertrailapp.com"
 papertrail_port: 45551
 papertrail_preserve_fqdn: 'off'
+papertrail_ca_bundle_checksum: "sha256:7019189e20ed695e9092e67d91a3b37249474f4c4c6355193ce6d2cb648f147c"
 papertrail_remote_syslog_config_paths:
   upstart:
     path: /etc/init/remote_syslog.conf

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     trusty.vm.provision "ansible" do |ansible|
       ansible.playbook = "site.yml"
-      ansible.sudo = true
+      ansible.become = true
     end
   end
 
@@ -20,7 +20,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     xenial.vm.provision "ansible" do |ansible|
       ansible.playbook = "site.yml"
-      ansible.sudo = true
+      ansible.become = true
     end
   end
 end

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An Ansible role for installing Papertrail.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.4
+  min_ansible_version: 2.4
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
            dest="/usr/local/src/remote_syslog_{{ papertrail_version }}_linux_amd64.tar.gz"
   register: remote_syslog_download
 
-- include: extract-remote-syslog.yml
+- include_tasks: extract-remote-syslog.yml
   when: remote_syslog_download.changed
 
 - name: Configure Rsyslog to use Papertrail

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download Papertrail PEM
   get_url: url="https://papertrailapp.com/tools/papertrail-bundle.pem"
            dest="/etc/papertrail-bundle.pem"
-           checksum="sha256:7019189e20ed695e9092e67d91a3b37249474f4c4c6355193ce6d2cb648f147c"
+           checksum="{{ papertrail_ca_bundle_checksum }}"
            mode=0644
 
 - name: Install TLS support for Rsyslog


### PR DESCRIPTION
Parametrize the Papertrail CA bundle checksum so that users can verify new CA bundle releases without waiting for us to update the role. Additionally, update the checksum to match that of the upcoming new bundle. Additionally, fix deprecation warnings generated by both the role and the Vagrant configuration used for tests. 

Fixes #13 

# Testing
- Hold off on testing until the new CA bundle is available
- Once it's live, run tests according to the directions in the `README`.
- Ensure that the VM provisions successfully
- Also make sure no deprecation warnings are present.