### PR TITLE
Do not hardcode Papertrail CA bundle checksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ An Ansible role for installing [Papertrail](https://papertrailapp.com).
 ## Role Variables
 
 - `papertrail_version` - Release of [remote_syslog2](https://github.com/papertrail/remote_syslog2) to use
-- `papertrail_ca_bundle_checksum` - Checksum for Papertrail CA bundle (default: `sha256:7019189e20ed695e9092e67d91a3b37249474f4c4c6355193ce6d2cb648f147c`)
 - `papertrail_conf` - Application logs configuration file (default: `/etc/log_files.yml`)
 - `papertrail_host` - Host for Papertrail's logging endpoint (default: `logs2.papertrail.com`)
 - `papertrail_port` - Port for Papertrail's logging endpoint (default: `45551`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,6 @@ papertrail_conf: "/etc/log_files.yml"
 papertrail_host: "logs2.papertrailapp.com"
 papertrail_port: 45551
 papertrail_preserve_fqdn: "off"
-papertrail_ca_bundle_checksum: "sha256:79ea479e9f329de7075c40154c591b51eb056d458bc4dff76d9a4b9c6c4f6d0b"
 papertrail_remote_syslog_config_paths:
   upstart:
     path: /etc/init/remote_syslog.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,6 @@
 - name: Download Papertrail PEM
   get_url: url="https://papertrailapp.com/tools/papertrail-bundle.pem"
            dest="/etc/papertrail-bundle.pem"
-           checksum="{{ papertrail_ca_bundle_checksum }}"
            mode=0644
 
 - name: Install TLS support for Rsyslog


### PR DESCRIPTION
**Problem:**
[As per Papertrail docs](https://help.papertrailapp.com/kb/configuration/encrypting-remote-syslog-with-tls-ssl/#download-root-certificates) it is not recommended to hard-code checksum of Papertrail CA bundle. Since it is fetched via HTTPS from `papertrailapp.com` that should offer enough protection against MiTM.